### PR TITLE
add actions to disable and enable plugins

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -54,6 +54,41 @@ module.exports.devtools = function (parent) {
                     });
                 });
             break;
+            case 'disableAllPlugins': {
+                obj.meshServer.db.getPlugins(function(err, docs) {
+                    if (err) { console.log('PLUGIN: devtools:', err); return; }
+                    let pendingUpdates = 0;
+                    for (const doc of docs) {
+                        if (doc.shortName === 'devtools' || doc.status === 0) { continue; }
+                        ++pendingUpdates;
+                        console.log('PLUGIN: devtools: disabling plugin:', doc.shortName);
+                        doc._devtools_previousStatus = doc.status;
+                        doc.status = 0;
+                        obj.meshServer.db.updatePlugin(doc._id, doc, function() {
+                            if (--pendingUpdates == 0 ) { console.log('PLUGIN: devtools:', command.pluginaction, 'DONE'); }
+                        })
+                    }
+                });
+                break;
+            }
+            case 'enablePreviouslyDisabledPlugins': {
+                obj.meshServer.db.getPlugins(function(err, docs) {
+                    if (err) { console.log('PLUGIN: devtools:', err); return; }
+                    let pendingUpdates = 0;
+                    for (const doc of docs) {
+                        const previousStatus = (+doc._devtools_previousStatus) ?? 0;
+                        if (isNaN(previousStatus) || previousStatus === 0) { continue; }
+                        ++pendingUpdates;
+                        console.log('PLUGIN: devtools: enabling plugin:', doc.shortName);
+                        doc.status = previousStatus;
+                        delete doc._devtools_previousStatus;
+                        obj.meshServer.db.updatePlugin(doc._id, doc, function() {
+                            if (--pendingUpdates == 0 ) { console.log('PLUGIN: devtools:', command.pluginaction, 'DONE'); }
+                        })
+                    }
+                });
+                break;
+            }
             case 'restartServer':
                 process.exit(123);
             default:

--- a/readme.md
+++ b/readme.md
@@ -20,4 +20,6 @@ Restart your MeshCentral server after making this change.
 - Force Refresh the PluginHandler
 - Edit a plugin config directly
 - Remove a plugin config from the database
+- Disable all plugins at once
+- Enable a single plugin or all previously disabled plugins
 - Restart the server

--- a/views/admin.handlebars
+++ b/views/admin.handlebars
@@ -22,6 +22,25 @@
     var deletePluginConfigEx = function() {
         parent.meshserver.send({ action: 'plugin', plugin: 'devtools', pluginaction: 'deletePluginConfig', id: parent.Q('dtDeletePluginConf').value });
     };
+    var disableAllPluginsEx = function() {
+        parent.meshserver.send({ action: 'plugin', plugin: 'devtools', pluginaction: 'disableAllPlugins' });
+    }
+    var enablePluginEx = function() {
+        const id = parent.Q('dtEnablePlugin').value;
+        let conf;
+        parent.installedPluginList.some((doc) => (doc._id === id && ((conf = doc), true)));
+        if (conf._devtools_previousStatus) {
+            conf.status = conf._devtools_previousStatus;
+            delete conf._devtools_previousStatus;
+        } else {
+            conf.status = 1;
+        }
+        console.log(conf);
+        parent.meshserver.send({ action: 'plugin', plugin: 'devtools', pluginaction: 'savePluginConfig', id, conf });
+    };
+    var enablePreviouslyDisabledPluginsEx = function() {
+        parent.meshserver.send({ action: 'plugin', plugin: 'devtools', pluginaction: 'enablePreviouslyDisabledPlugins' });
+    }
     var restartServerEx = function() {
         parent.meshserver.send({ action: 'plugin', plugin: 'devtools', pluginaction: 'restartServer' });
     }
@@ -57,8 +76,23 @@
         sel += '</select>';
         parent.setDialogMode(2, "Delete which Plugin?", 3, deletePluginConfigEx, sel);
     }
+    function disableAllPlugins() {
+        parent.setDialogMode(2, "Disable all plugins?", 3, disableAllPluginsEx, 'Are you sure you want to disable all plugins except the Dev Tools?');
+    }
+    function enablePreviouslyDisabledPlugins() {
+        parent.setDialogMode(2, "Enable previously disabled plugins?", 3, enablePreviouslyDisabledPluginsEx, 'Are you sure you want to enable all previously disabled plugins?');
+    }
+    function enablePlugin() {
+        var sel = '<select id="dtEnablePlugin">'
+        parent.installedPluginList.forEach((plugin) => {
+            if (plugin.status) { return; }
+            sel += `<option${plugin._devtools_previousStatus ? ' style="font-weight: bold;"' : ''} value="${plugin._id}">${plugin.name}</option>`;
+        });
+        sel += '</select>';
+        parent.setDialogMode(2, "Enable which Plugin?", 3, enablePluginEx, sel);
+    }
     function restartServer() {
-        parent.setDialogMode(2, "Restart Server?", 3, restartServerEx, 'Are you sure?');
+        parent.setDialogMode(2, "Restart Server?", 3, restartServerEx, 'Are you sure you want to restart the server?');
     }
     function initPtools() {
         parent.pluginHandler.devtools.loadEditPluginConfig = function(args, msg) {
@@ -84,6 +118,9 @@
   <a href="#" onclick="deletePluginConfig(); return false;">Delete a plugin config from the database</a><br /><br />
   <a href="#" onclick="refreshHandler(); return false;">Refresh PluginHandler</a><br /><br />
   <a href="#" onclick="editPluginConfig(); return false;">Edit a plugin config</a><br /><br />
+  <a href="#" onclick="disableAllPlugins(); return false;">Disable all plugins</a> except the Dev Tools<br /><br />
+  <a href="#" onclick="enablePlugin(); return false;">Enable a plugin</a><br /><br />
+  <a href="#" onclick="enablePreviouslyDisabledPlugins(); return false;">Enable previously disabled plugins</a><br /><br />
   <a href="#" onclick="restartServer(); return false;">Restart Server</a><br /><br />
 </div>
 </body>


### PR DESCRIPTION
Additional actions to further simplify development and testing:

- **`Disable all plugins except the Dev Tools`**: All enabled plugins are disable and the current `status` is stored as `_devtools_previousStatus`
- **``Enable a plugin``**: (Re-)enable plugin (w/o installing it). Previously disabled plugins are emphasized in the select-list.
- **``Enable previously disabled plugins``**: Restore state from `_devtools_previousStatus` if set.